### PR TITLE
当session被Refresh后，被clone将导致重复验证的情况

### DIFF
--- a/db/mongo.go
+++ b/db/mongo.go
@@ -107,6 +107,7 @@ func MustNewMgoSessions(config *MongoConfig) []*mgo.Session {
 			for {
 				if err := s.Ping(); err != nil {
 					s.Refresh()
+					s.Ping()
 				}
 				time.Sleep(time.Second)
 			}


### PR DESCRIPTION
所有的session连接都是通过预先申请的8个Session Clone出来的。

clone的操作是直接复制session里面的一个 masterSocket 和 slaveSocket
当session需要执行一个操作的时候，需要 acquireSocket, 会从 masterSocket/slaveSocket 获取，
如果这两个都为空，则会直接新建一个 socket (从 mongoServer 的连接池获取)，然后发送验证信息(即使连接被复用了，但是不同session的认证信息可能不同)。然后set进session的 masterSocket/slaveSocket，后续再通过这个session的操作会直接使用这个认证信息

那么问题来了，如果预先申请的session里面的masterSocket和slaveSocket 为空，则clone出去的session就没有可用的socket，会新建一个。但是clone出去的session默认的使用范式是 new一个后立刻关闭，也就是说这个新申请的socket并不会被复用(指的是认证信息)，在close后就会被扔回连接池。认证信息不会反馈回最开始申请的8个session里面，导致此后通过这个session clone的session在进行通讯时都需要进行认证。

那么，session的masterSocket/slaveSocket 什么情况下会为空？
1. session关闭的时候
2. session刚新建还没有发起请求的时候
3. 被refresh的时候 (包括SetMode时refresh=true)

代码内的goroutine的作用是通过不断的ping来验证socket的有效性，session下的socket都是对应到实际的连接的，不是线程池，所以在出现错误的时候，需要通过Refresh将他们设置为空，在下次请求时自动从连接池申请一个新连接。所以，在Refresh到下次ping的时候，他的socket都是空的。

临时的解决方案是在refresh之后，立刻进行ping。
当前使用session的方式在待认证的时候并不正确，待找到正确的姿势

