### PR TITLE
e2e,internal/parser/mysqlr,pkg/orm: fetch by uk should accepts multiple args

### DIFF
--- a/e2e/mongo/user/gen_User_struct.go
+++ b/e2e/mongo/user/gen_User_struct.go
@@ -1,8 +1,10 @@
 package user
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
+import (
+	"time"
 
-import "time"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
 
 var _ time.Time
 

--- a/e2e/mysqlr/blog.yaml
+++ b/e2e/mysqlr/blog.yaml
@@ -14,3 +14,6 @@ Blog:
     - CreatedAt: timestamp
     - UpdatedAt: timeint
   primary: [Id, UserId]
+  uniques:
+  - [Title]
+  - [UserId,Title]

--- a/e2e/mysqlr/gen.mysqlr.blog.go
+++ b/e2e/mysqlr/gen.mysqlr.blog.go
@@ -181,6 +181,133 @@ func (u *IdUserIdOfBlogPK) Columns() []string {
 	}
 }
 
+type UserIdTitleOfBlogUK struct {
+	UserId int32
+	Title  string
+}
+
+type UserIdTitleOfBlogUKs []*UserIdTitleOfBlogUK
+
+func NewUserIdTitleOfBlogUKs(s []*UserIdTitleOfBlogUK) UserIdTitleOfBlogUKs {
+	return UserIdTitleOfBlogUKs(s)
+}
+
+func (us UserIdTitleOfBlogUKs) SQLFormat(limit bool) string {
+	in := orm.NewMultiFieldIN([]string{"user_id", "title"})
+	for _, u := range us {
+		tuple := make([]any, 2)
+		tuple[0] = u.UserId
+		tuple[1] = u.Title
+		in.Add(tuple)
+	}
+	return orm.SQLWhere([]string{in.SQLFormat()})
+}
+
+func (us UserIdTitleOfBlogUKs) SQLParams() []any {
+	var ret []any
+	for _, u := range us {
+		ret = append(ret, u.UserId)
+		ret = append(ret, u.Title)
+	}
+	return ret
+}
+
+func (u *UserIdTitleOfBlogUK) Key() string {
+	strs := []string{
+		"UserId",
+		fmt.Sprintf("%v", u.UserId),
+		"Title",
+		fmt.Sprintf("%v", u.Title),
+	}
+	return strings.Join(strs, ":")
+}
+
+func (u *UserIdTitleOfBlogUK) SQLFormat(limit bool) string {
+	in := orm.NewMultiFieldIN([]string{"user_id", "title"})
+	tuple := make([]any, 2)
+	tuple[0] = u.UserId
+	tuple[1] = u.Title
+	in.Add(tuple)
+	return orm.SQLWhere([]string{in.SQLFormat()})
+}
+
+func (u *UserIdTitleOfBlogUK) SQLParams() []any {
+	var ret []any
+	ret = append(ret, u.UserId)
+	ret = append(ret, u.Title)
+	return ret
+}
+
+func (u *UserIdTitleOfBlogUK) SQLLimit() int {
+	return 1
+}
+
+func (u *UserIdTitleOfBlogUK) Limit(n int) {
+}
+
+func (u *UserIdTitleOfBlogUK) Offset(n int) {
+}
+
+type TitleOfBlogUK struct {
+	Title string
+}
+
+type TitleOfBlogUKs []*TitleOfBlogUK
+
+func NewTitleOfBlogUKs(s []*TitleOfBlogUK) TitleOfBlogUKs {
+	return TitleOfBlogUKs(s)
+}
+
+func (us TitleOfBlogUKs) SQLFormat(limit bool) string {
+	in := orm.NewMultiFieldIN([]string{"title"})
+	for _, u := range us {
+		tuple := make([]any, 1)
+		tuple[0] = u.Title
+		in.Add(tuple)
+	}
+	return orm.SQLWhere([]string{in.SQLFormat()})
+}
+
+func (us TitleOfBlogUKs) SQLParams() []any {
+	var ret []any
+	for _, u := range us {
+		ret = append(ret, u.Title)
+	}
+	return ret
+}
+
+func (u *TitleOfBlogUK) Key() string {
+	strs := []string{
+		"Title",
+		fmt.Sprintf("%v", u.Title),
+	}
+	return strings.Join(strs, ":")
+}
+
+func (u *TitleOfBlogUK) SQLFormat(limit bool) string {
+	in := orm.NewMultiFieldIN([]string{"title"})
+	tuple := make([]any, 1)
+	tuple[0] = u.Title
+	in.Add(tuple)
+	return orm.SQLWhere([]string{in.SQLFormat()})
+}
+
+func (u *TitleOfBlogUK) SQLParams() []any {
+	var ret []any
+	ret = append(ret, u.Title)
+	return ret
+}
+
+func (u *TitleOfBlogUK) SQLLimit() int {
+	return 1
+}
+
+func (u *TitleOfBlogUK) Limit(n int) {
+}
+
+func (u *TitleOfBlogUK) Offset(n int) {
+}
+
 type StatusOfBlogIDX struct {
 	Status int32
 	offset int
@@ -382,6 +509,72 @@ func (m *_BlogDBMgr) FindByStatusGroup(ctx context.Context, items []int32) ([]*B
 }
 
 // uniques
+
+func (m *_BlogDBMgr) FetchByUserIdTitle(ctx context.Context, uniq *UserIdTitleOfBlogUK) (*Blog, error) {
+	obj := BlogMgr.NewBlog()
+
+	query := fmt.Sprintf("SELECT %s FROM blogs %s", strings.Join(obj.GetColumns(), ","), uniq.SQLFormat(true))
+	objs, err := m.FetchBySQL(ctx, query, uniq.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs[0], nil
+	}
+	return nil, fmt.Errorf("FetchByUserIdTitle: %w", sql.ErrNoRows)
+}
+
+func (m *_BlogDBMgr) FetchByUserIdTitles(ctx context.Context, us []*UserIdTitleOfBlogUK) ([]*Blog, error) {
+	obj := BlogMgr.NewBlog()
+
+	if len(us) == 0 {
+		return nil, nil
+	}
+	u := NewUserIdTitleOfBlogUKs(us)
+	query := fmt.Sprintf("SELECT %s FROM blogs %s", strings.Join(obj.GetColumns(), ","), u.SQLFormat(true))
+	objs, err := m.FetchBySQL(ctx, query, u.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs, nil
+	}
+	return nil, fmt.Errorf("FetchByUserIdTitles: %w", sql.ErrNoRows)
+}
+
+func (m *_BlogDBMgr) FetchByTitles(ctx context.Context, _titles []string) ([]*Blog, error) {
+	in := orm.NewFieldIN("title")
+	for _, item := range _titles {
+		in.Add(item)
+	}
+	obj := BlogMgr.NewBlog()
+	where := orm.SQLWhere([]string{in.SQLFormat()})
+	query := fmt.Sprintf("SELECT %s FROM blogs %s", strings.Join(obj.GetColumns(), ","), where)
+	objs, err := m.FetchBySQL(ctx, query, in.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs, nil
+	}
+	return nil, fmt.Errorf("FetchByTitles: %w", sql.ErrNoRows)
+}
+
+func (m *_BlogDBMgr) FetchByTitle(ctx context.Context, _title string) (*Blog, error) {
+	in := orm.NewFieldIN("title")
+	in.Add(_title)
+	obj := BlogMgr.NewBlog()
+	where := orm.SQLWhere([]string{in.SQLFormat()})
+	query := fmt.Sprintf("SELECT %s FROM blogs %s", strings.Join(obj.GetColumns(), ","), where)
+	objs, err := m.FetchBySQL(ctx, query, in.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs[0], nil
+	}
+	return nil, fmt.Errorf("FetchByTitle: %w", sql.ErrNoRows)
+}
 
 func (m *_BlogDBMgr) FindOne(ctx context.Context, unique Unique) (PrimaryKey, error) {
 	objs, err := m.queryLimit(ctx, unique.SQLFormat(true), unique.SQLLimit(), unique.SQLParams()...)

--- a/e2e/mysqlr/gen.script.mysqlr.blog.sql
+++ b/e2e/mysqlr/gen.script.mysqlr.blog.sql
@@ -11,6 +11,7 @@ CREATE TABLE `blogs` (
 	`readed` INT(11) NOT NULL DEFAULT '0',
 	`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	`updated_at` BIGINT(20) NOT NULL DEFAULT '0',
-	PRIMARY KEY(`id`,`user_id`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'blogs';
+	PRIMARY KEY(`id`,`user_id`),
+	UNIQUE KEY `uniq_title_of_blog_uk` (`title`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT 'blogs';
 CREATE INDEX status_of_blog_idx ON blogs(status);
 

--- a/e2e/mysqlr/mysqlr_test.go
+++ b/e2e/mysqlr/mysqlr_test.go
@@ -2,6 +2,7 @@ package mysqlr
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"strconv"
@@ -65,6 +66,46 @@ func TestBlogsCRUD(t *testing.T) {
 		count, err := BlogDBMgr(db).SearchConditionsCount(ctx, []string{"user_id = ?"}, 1)
 		assert.NoError(t, err)
 		assert.Equal(t, int64(1), count)
+	})
+
+	t.Run("GetByPrimaryKey", func(t *testing.T) {
+		b, err := BlogDBMgr(db).FetchByPrimaryKey(ctx, 1, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), b.Id)
+	})
+
+	t.Run("GetByUniqueKey", func(t *testing.T) {
+		bs, err := BlogDBMgr(db).FetchByTitles(ctx, []string{"test"})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(bs))
+	})
+
+	t.Run("GetUniqueMultiKey", func(t *testing.T) {
+		b, err := BlogDBMgr(db).FetchByUserIdTitle(ctx, &UserIdTitleOfBlogUK{
+			UserId: 1,
+			Title:  "test",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), b.Id)
+	})
+
+	t.Run("GetUniqueMultiKeyByBatch", func(t *testing.T) {
+		bs, err := BlogDBMgr(db).FetchByUserIdTitles(ctx, []*UserIdTitleOfBlogUK{
+			{UserId: 1, Title: "test"},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(bs))
+	})
+
+	t.Run("GetByUniqueKeyNoRows", func(t *testing.T) {
+		_, err := BlogDBMgr(db).FetchByTitle(ctx, "tet")
+		assert.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("GetByIndex", func(t *testing.T) {
+		bs, err := BlogDBMgr(db).FindAllByStatus(ctx, 1)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(bs))
 	})
 
 	t.Run("Update", func(t *testing.T) {

--- a/e2e/mysqlr/user.yaml
+++ b/e2e/mysqlr/user.yaml
@@ -9,3 +9,5 @@ User:
     - CreatedAt: int64
     - UpdatedAt: int64
   primary: [Id, UserId]
+  uniques:
+  - [Name,UserId]

--- a/internal/parser/mysqlr/field.go
+++ b/internal/parser/mysqlr/field.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -527,6 +528,14 @@ func (fs Fields) GetConstructor() string {
 	}
 	params = append(params, "")
 	return strings.Join(params, ",\n")
+}
+
+func (fs Fields) GetFieldNames() string {
+	var names []string
+	for _, f := range fs {
+		names = append(names, strconv.Quote(f.FieldName()))
+	}
+	return fmt.Sprintf("[]string{%s}", strings.Join(names, ", "))
 }
 
 func Camel2Name(s string) string {

--- a/internal/parser/mysqlr/index.go
+++ b/internal/parser/mysqlr/index.go
@@ -83,3 +83,7 @@ func (idx *Index) build(suffix string) error {
 func (idx *Index) GetConstructor() string {
 	return Fields(idx.Fields).GetConstructor()
 }
+
+func (idx *Index) GetFieldNames() string {
+	return Fields(idx.Fields).GetFieldNames()
+}

--- a/internal/parser/mysqlr/tpl/object_read.gogo
+++ b/internal/parser/mysqlr/tpl/object_read.gogo
@@ -225,11 +225,47 @@ func (m *_{{$obj.Name}}DBMgr) FindBy{{$index.FirstField.Name}}Group(ctx context.
 // uniques
 {{- range $unique:=$uniques}}
 
-func (m *_{{$obj.Name}}DBMgr) FetchBy{{$unique.GetFuncName}}(ctx context.Context,{{$unique.GetFuncParam}}) (*{{$obj.Name}}, error) {
-	obj := {{$obj.Name}}Mgr.New{{$obj.Name}}()
-	uniq := &{{$unique.Name}}{
-	{{$unique.GetConstructor}}
+{{ $firstUniqueField := $unique.FirstField }}
+
+{{- if $unique.IsSingleField}}
+func (m *_{{$obj.Name}}DBMgr) FetchBy{{$unique.GetFuncName}}s(ctx context.Context,{{$firstUniqueField.GetNames}} []{{$firstUniqueField.GetType}}) ([]*{{$obj.Name}}, error) {
+	in:= orm.NewFieldIN("{{$firstUniqueField.FieldName}}")
+	for _, item := range {{$firstUniqueField.GetNames}} {
+		in.Add(item)
 	}
+	obj := {{$obj.Name}}Mgr.New{{$obj.Name}}()
+	where := orm.SQLWhere([]string{in.SQLFormat()})
+	query := fmt.Sprintf("SELECT %s FROM {{$obj.FromDB}} %s", strings.Join(obj.GetColumns(), ","), where)
+	objs, err := m.FetchBySQL(ctx,query, in.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs, nil
+	}
+	return nil, fmt.Errorf("FetchBy{{$unique.GetFuncName}}s: %w", sql.ErrNoRows)
+}
+
+func (m *_{{$obj.Name}}DBMgr) FetchBy{{$unique.GetFuncName}}(ctx context.Context,{{$firstUniqueField.GetName}} {{$firstUniqueField.GetType}}) (*{{$obj.Name}}, error) {
+	in:= orm.NewFieldIN("{{$firstUniqueField.FieldName}}")
+	in.Add({{$firstUniqueField.GetName}})
+	obj := {{$obj.Name}}Mgr.New{{$obj.Name}}()
+	where := orm.SQLWhere([]string{in.SQLFormat()})
+	query := fmt.Sprintf("SELECT %s FROM {{$obj.FromDB}} %s", strings.Join(obj.GetColumns(), ","), where)
+	objs, err := m.FetchBySQL(ctx,query, in.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs[0], nil
+	}
+	return nil, fmt.Errorf("FetchBy{{$unique.GetFuncName}}: %w", sql.ErrNoRows)
+}
+
+{{- else }}
+
+func (m *_{{$obj.Name}}DBMgr) FetchBy{{$unique.GetFuncName}}(ctx context.Context,uniq *{{$unique.Name}}) (*{{$obj.Name}}, error) {
+	obj := {{$obj.Name}}Mgr.New{{$obj.Name}}()
 
 	query := fmt.Sprintf("SELECT %s FROM {{$obj.FromDB}} %s", strings.Join(obj.GetColumns(), ","), uniq.SQLFormat(true))
 	objs, err := m.FetchBySQL(ctx,query, uniq.SQLParams()...)
@@ -239,8 +275,28 @@ func (m *_{{$obj.Name}}DBMgr) FetchBy{{$unique.GetFuncName}}(ctx context.Context
 	if len(objs) > 0 {
 		return objs[0], nil
 	}
-	return nil, fmt.Errorf("{{$obj.Name}} fetch record not found")
+	return nil, fmt.Errorf("FetchBy{{$unique.GetFuncName}}: %w", sql.ErrNoRows)
 }
+
+func (m *_{{$obj.Name}}DBMgr) FetchBy{{$unique.GetFuncName}}s(ctx context.Context,us []*{{$unique.Name}}) ([]*{{$obj.Name}}, error) {
+	obj := {{$obj.Name}}Mgr.New{{$obj.Name}}()
+
+	if len(us) == 0 {
+		return nil, nil
+	}
+	u := New{{$unique.Name}}s(us)
+	query := fmt.Sprintf("SELECT %s FROM {{$obj.FromDB}} %s", strings.Join(obj.GetColumns(), ","), u.SQLFormat(true))
+	objs, err := m.FetchBySQL(ctx,query, u.SQLParams()...)
+	if err != nil {
+		return nil, err
+	}
+	if len(objs) > 0 {
+		return objs, nil
+	}
+	return nil, fmt.Errorf("FetchBy{{$unique.GetFuncName}}s: %w", sql.ErrNoRows)
+}
+
+{{end}}
 {{- end}}
 
 func (m *_{{$obj.Name}}DBMgr) FindOne(ctx context.Context,unique Unique) (PrimaryKey, error) {

--- a/internal/parser/mysqlr/tpl/unique_key.gogo
+++ b/internal/parser/mysqlr/tpl/unique_key.gogo
@@ -1,12 +1,40 @@
 {{define "mysqlr_object_unique"}}
 {{$unique := .}}
 {{$obj := .Obj}}
-{{$primaryField := .Obj.PrimaryField}}
+
 
 type {{$unique.Name}} struct{
 	{{- range $j, $field := $unique.Fields}}
 	{{$field.Name}} {{$field.GetType}}
 	{{- end}}
+}
+
+type {{$unique.Name}}s []*{{$unique.Name}}
+
+func New{{$unique.Name}}s(s []*{{$unique.Name}}) {{$unique.Name}}s {
+	return {{$unique.Name}}s(s)
+}
+
+func (us {{$unique.Name}}s) SQLFormat(limit bool) string {
+	in := orm.NewMultiFieldIN({{$unique.GetFieldNames}})
+	for _, u := range us {
+		tuple := make([]any,{{ len $unique.Fields }})
+	{{- range $j, $field := $unique.Fields}}
+		tuple[{{$j}}] = u.{{$field.Name}}
+	{{- end}}
+		in.Add(tuple)
+	}
+	return orm.SQLWhere([]string{in.SQLFormat()})
+}
+
+func (us {{$unique.Name}}s) SQLParams() []any {
+	var ret []any
+	for _, u := range us {
+	{{- range $j, $field := $unique.Fields}}
+		ret = append(ret, u.{{$field.Name}})
+	{{- end }}
+	}
+	return ret
 }
 
 func (u *{{$unique.Name}}) Key() string {
@@ -16,28 +44,29 @@ func (u *{{$unique.Name}}) Key() string {
 			{{- if $field.IsEncode}}
 			orm.Encode(fmt.Sprint(u.{{$field.Name}})),
 			{{- else}}
-			fmt.Sprint(u.{{$field.Name}}),
+			fmt.Sprintf("%v",u.{{$field.Name}}),
 			{{- end}}
 		{{- end}}
 	}
-	return fmt.Sprintf("%s", strings.Join(strs, ":"))
+	return  strings.Join(strs, ":")
 }
 
 func (u *{{$unique.Name}}) SQLFormat(limit bool) string {
-	conditions := []string{
-		{{- range $j, $field := $unique.Fields}}
-		"{{$field.FieldName}} = ?",
-		{{- end}}
-	}
-	return orm.SQLWhere(conditions)
+	in := orm.NewMultiFieldIN({{$unique.GetFieldNames}})
+	tuple := make([]any,{{ len $unique.Fields }})
+	{{- range $j, $field := $unique.Fields}}
+	tuple[{{$j}}] = u.{{$field.Name}}
+	{{- end}}
+	in.Add(tuple)
+	return orm.SQLWhere([]string{in.SQLFormat()})
 }
 
-func (u *{{$unique.Name}}) SQLParams() []interface{} {
-	return []interface{}{
-		{{- range $j, $field := $unique.Fields}}
-		u.{{$field.Name}},
-		{{- end}}
-	}
+func (u *{{$unique.Name}}) SQLParams() []any {
+	var ret []any
+	{{- range $j, $field := $unique.Fields}}
+		ret = append(ret, u.{{$field.Name}})
+	{{- end }}
+	return ret
 }
 
 func (u *{{$unique.Name}}) SQLLimit() int {

--- a/pkg/orm/in.go
+++ b/pkg/orm/in.go
@@ -1,0 +1,87 @@
+package orm
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type FieldMultiIN struct {
+	rawFieldsLen int
+	in           *FieldIN
+}
+
+func NewMultiFieldIN(fields []string) *FieldMultiIN {
+	var b bytes.Buffer
+	b.WriteByte('(')
+	b.WriteString(strings.Join(fields, ","))
+	b.WriteByte(')')
+	return &FieldMultiIN{
+		rawFieldsLen: len(fields),
+		in: &FieldIN{
+			Field: b.String(),
+		},
+	}
+}
+
+func (in *FieldMultiIN) Add(v []any) error {
+	if in.rawFieldsLen == 0 || len(v) == 0 {
+		return errors.New("builder: fields length and passed-in value length should above zero")
+	}
+	if len(v)%in.rawFieldsLen != 0 {
+		return errors.New("builder: passed-in value length should be integer multiple than fields length")
+	}
+	in.in.Params = append(in.in.Params, v...)
+	var b bytes.Buffer
+	b.WriteByte('(')
+	for index := range v {
+		if index == len(v)-1 {
+			b.WriteByte('?')
+			continue
+		}
+		b.WriteString("?,")
+	}
+	b.WriteByte(')')
+	in.in.holders = append(in.in.holders, b.String())
+	return nil
+}
+
+func (in *FieldMultiIN) SQLFormat() string {
+	return in.in.SQLFormat()
+}
+
+func (in *FieldMultiIN) SQLParams() []any {
+	return in.in.SQLParams()
+}
+
+type FieldIN struct {
+	Field   string
+	Params  []any
+	holders []string
+}
+
+func NewFieldIN(field string) *FieldIN {
+	return &FieldIN{
+		Field:   field,
+		Params:  []any{},
+		holders: []string{},
+	}
+}
+
+func (in *FieldIN) Add(v interface{}) *FieldIN {
+	in.Params = append(in.Params, v)
+	in.holders = append(in.holders, "?")
+	return in
+}
+
+func (in *FieldIN) SQLFormat() string {
+	if len(in.Params) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s IN (%s)", in.Field, strings.Join(in.holders, ","))
+}
+
+func (in *FieldIN) SQLParams() []interface{} {
+	return in.Params
+}


### PR DESCRIPTION
* Adds support for multiple unique key , e.g.: 

  if your `uniques` have a constraint like : `uniques: [[Id,UserId]]` ,  now , ezorm-v2 mysqlr driver will really generate a method for you . like this:
```Go
func (m *_BlogDBMgr) FetchByIdUserId(ctx context.Context, uniq  *IdUserIdOfBlogUK) (*Blog, error) {}
```

* Adds support for pass in a uk slice and return the model slice . e.g.:

```Go
func (m *_BlogDBMgr) FetchByTitles(ctx context.Context, _titles []string) ([]*Blog, error) {}
```

