### PR TITLE
Fix auto commit transaction occur panic

### DIFF
--- a/v2/pkg/orm/db.go
+++ b/v2/pkg/orm/db.go
@@ -156,6 +156,11 @@ func (store *DBStore) BeginTx() (*DBTx, error) {
 }
 
 func (tx *DBTx) Close() error {
+	if re := recover(); re != nil {
+		tx.tx.Rollback()
+		panic(re)
+	}
+
 	if tx.err != nil {
 		return tx.tx.Rollback()
 	}


### PR DESCRIPTION
## Issue

In current version, transaction recommend usage like this:

```go
func foo() {
    tx, err := db.BeginTx()
    // error handling
    defer tx.Close()
}
```

Unexpectedly, transaction will be committed in `tx.Close()` if any panic occured.

## Expected Behavior

The transaction should be rollback automatically instead.