### PR TITLE
tpl/mongo: add mongo's mtest for mocking test purpose

### DIFF
--- a/e2e/mongo/nested/gen_User_mongo_orm.go
+++ b/e2e/mongo/nested/gen_User_mongo_orm.go
@@ -15,6 +15,8 @@ import (
 // To import `time` package globally to satisfy `time.Time` index in yaml definition
 var _ time.Time
 
+const ColUser = "mongo_e2e.User"
+
 var UserIndexes = []mongo.IndexModel{
 	{
 		Keys: UserIndexKey_Username,
@@ -25,7 +27,7 @@ var UserIndexes = []mongo.IndexModel{
 }
 
 var UserIndexesFunc = func() {
-	orm.SetupIndexModel(Col("mongo_e2e.User"), UserIndexes)
+	orm.SetupIndexModel(Col(ColUser), UserIndexes)
 }
 var UserIndexKey_Username = bson.D{
 	{Key: "Username", Value: 1},

--- a/e2e/mongo/nested/gen_User_mongo_orm_test.go
+++ b/e2e/mongo/nested/gen_User_mongo_orm_test.go
@@ -12,6 +12,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
+var _ time.Time
+
 type UserSuite struct {
 	suite.Suite
 	ctx context.Context

--- a/e2e/mongo/nested/gen_User_mongo_orm_test.go
+++ b/e2e/mongo/nested/gen_User_mongo_orm_test.go
@@ -1,0 +1,434 @@
+package nested
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+type UserSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *UserSuite) SetupTest() {
+	s.ctx = context.TODO()
+}
+
+// TearDownTest runs after each test in the suite.
+func (s *UserSuite) TearDownTest() {
+}
+
+// TestSave tests the Save method with various scenarios
+func (s *UserSuite) TestSave() {
+	cases := []struct {
+		name    string
+		data    User
+		wantErr bool
+	}{
+		{
+			name: "save_success",
+			data: User{
+				// ID will be auto-generated
+				UserId:       1,
+				Username:     "test_username",
+				Age:          1,
+				Blogs:        []Blog{}, // TODO: Set appropriate test value
+				RegisterDate: time.Now(),
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "acknowledged", Value: true},
+						{Key: "matchedCount", Value: 1},
+						{Key: "modifiedCount", Value: 1},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				_, err := obj.Save(s.ctx)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOneAndSave tests the FindOneAndSave method
+func (s *UserSuite) TestFindOneAndSave() {
+	cases := []struct {
+		name    string
+		data    User
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "findOneAndSave_success",
+			data: User{
+				// ID will be auto-generated
+				UserId:       2,
+				Username:     "test_username",
+				Age:          2,
+				Blogs:        []Blog{}, // TODO: Set appropriate test value
+				RegisterDate: time.Now(),
+			},
+			query: bson.M{
+				"Username": "test_username",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				// FindOneAndUpdate returns the actual document
+				objectID := primitive.NewObjectID()
+				findOneAndUpdateResp := mtest.CreateSuccessResponse(bson.D{
+					{Key: "value", Value: bson.D{
+						{Key: "_id", Value: objectID},
+						{Key: UserMgoFieldUserId, Value: c.data.UserId},
+						{Key: UserMgoFieldUsername, Value: c.data.Username},
+						{Key: UserMgoFieldAge, Value: c.data.Age},
+						{Key: UserMgoFieldBlogs, Value: c.data.Blogs},
+						{Key: UserMgoFieldRegisterDate, Value: c.data.RegisterDate},
+					}},
+					{Key: "ok", Value: 1},
+				}...)
+				t.AddMockResponses(findOneAndUpdateResp)
+				obj := c.data
+				_, err := obj.FindOneAndSave(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestInsertUnique tests the InsertUnique method
+func (s *UserSuite) TestInsertUnique() {
+	cases := []struct {
+		name    string
+		data    User
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "insertUnique_success",
+			data: User{
+				// ID will be auto-generated
+				UserId:       3,
+				Username:     "unique_username",
+				Age:          3,
+				Blogs:        []Blog{}, // TODO: Set appropriate test value
+				RegisterDate: time.Now(),
+			},
+			query: bson.M{
+				"Username": "unique_username",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "ok", Value: 1},
+						{Key: "n", Value: 1},
+						{Key: "nModified", Value: 0},
+						{Key: "upserted", Value: bson.A{
+							bson.D{
+								{Key: "index", Value: 0},
+								{Key: "_id", Value: primitive.NewObjectID()},
+							},
+						}},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				saved, err := obj.InsertUnique(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.True(t, saved)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOne tests the FindOne method
+func (s *UserSuite) TestFindOne() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "findOne_success",
+			query: bson.M{
+				"Username": "test_username",
+			},
+			sortFields: UserMgoSortField_WRP{UserMgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				findResp := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldBlogs, Value: nil}, // TODO: Set appropriate test value
+					{Key: UserMgoFieldRegisterDate, Value: time.Now()},
+				})
+				t.AddMockResponses(findResp)
+				result, err := Get_UserMgr().FindOne(s.ctx, c.query, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Equal(t, "test_username", result.Username)
+				}
+			})
+		})
+	}
+}
+
+// TestQuery tests the Query method
+func (s *UserSuite) TestQuery() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "query_success",
+			query: bson.M{
+				"UserId": uint64(1),
+			},
+			limit:      10,
+			offset:     0,
+			sortFields: UserMgoSortField_WRP{UserMgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username_1"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldBlogs, Value: nil}, // TODO: Set appropriate test value
+					{Key: UserMgoFieldRegisterDate, Value: time.Now()},
+				})
+				getMore := mtest.CreateCursorResponse(1, "test.user", mtest.NextBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(2)},
+					{Key: UserMgoFieldUsername, Value: "test_username_2"},
+					{Key: UserMgoFieldAge, Value: int32(2)},
+					{Key: UserMgoFieldBlogs, Value: nil}, // TODO: Set appropriate test value
+					{Key: UserMgoFieldRegisterDate, Value: time.Now()},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, getMore, killCursors)
+				cursor, err := Get_UserMgr().Query(s.ctx, c.query, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, cursor)
+					// Close cursor to clean up
+					cursor.Close(s.ctx)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByUsername tests the FindByUsername method
+func (s *UserSuite) TestFindByUsername() {
+	cases := []struct {
+		name       string
+		username   string
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "findbyusername_success",
+			username:   "test_username",
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldBlogs, Value: nil}, // TODO: Set appropriate test value
+					{Key: UserMgoFieldRegisterDate, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserMgr().FindByUsername(s.ctx, c.username, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.username, result[0].Username)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByAge tests the FindByAge method
+func (s *UserSuite) TestFindByAge() {
+	cases := []struct {
+		name       string
+		age        int32
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "findbyage_success",
+			age:        int32(1),
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldBlogs, Value: nil}, // TODO: Set appropriate test value
+					{Key: UserMgoFieldRegisterDate, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserMgr().FindByAge(s.ctx, c.age, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.age, result[0].Age)
+				}
+			})
+		})
+	}
+}
+
+func TestUser(t *testing.T) {
+	suite.Run(t, &UserSuite{})
+}

--- a/e2e/mongo/user/gen_UserBlog_mongo_orm.go
+++ b/e2e/mongo/user/gen_UserBlog_mongo_orm.go
@@ -15,6 +15,8 @@ import (
 // To import `time` package globally to satisfy `time.Time` index in yaml definition
 var _ time.Time
 
+const ColUserBlog = "test_user_blog"
+
 var UserBlogIndexes = []mongo.IndexModel{
 	{
 		Keys: UserBlogIndexKey_UserId,
@@ -22,7 +24,7 @@ var UserBlogIndexes = []mongo.IndexModel{
 }
 
 var UserBlogIndexesFunc = func() {
-	orm.SetupIndexModel(Col("test_user_blog"), UserBlogIndexes)
+	orm.SetupIndexModel(Col(ColUserBlog), UserBlogIndexes)
 }
 var UserBlogIndexKey_UserId = bson.D{
 	{Key: "UserId", Value: 1},

--- a/e2e/mongo/user/gen_UserBlog_mongo_orm_test.go
+++ b/e2e/mongo/user/gen_UserBlog_mongo_orm_test.go
@@ -12,6 +12,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
+var _ time.Time
+
 type UserBlogSuite struct {
 	suite.Suite
 	ctx context.Context

--- a/e2e/mongo/user/gen_UserBlog_mongo_orm_test.go
+++ b/e2e/mongo/user/gen_UserBlog_mongo_orm_test.go
@@ -1,0 +1,363 @@
+package user
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+type UserBlogSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *UserBlogSuite) SetupTest() {
+	s.ctx = context.TODO()
+}
+
+// TearDownTest runs after each test in the suite.
+func (s *UserBlogSuite) TearDownTest() {
+}
+
+// TestSave tests the Save method with various scenarios
+func (s *UserBlogSuite) TestSave() {
+	cases := []struct {
+		name    string
+		data    UserBlog
+		wantErr bool
+	}{
+		{
+			name: "save_success",
+			data: UserBlog{
+				// ID will be auto-generated
+				UserId:  1,
+				BlogId:  1,
+				Content: "test_content",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "acknowledged", Value: true},
+						{Key: "matchedCount", Value: 1},
+						{Key: "modifiedCount", Value: 1},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				_, err := obj.Save(s.ctx)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOneAndSave tests the FindOneAndSave method
+func (s *UserBlogSuite) TestFindOneAndSave() {
+	cases := []struct {
+		name    string
+		data    UserBlog
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "findOneAndSave_success",
+			data: UserBlog{
+				// ID will be auto-generated
+				UserId:  2,
+				BlogId:  2,
+				Content: "test_content",
+			},
+			query: bson.M{
+				"Content": "test_content",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				// FindOneAndUpdate returns the actual document
+				objectID := primitive.NewObjectID()
+				findOneAndUpdateResp := mtest.CreateSuccessResponse(bson.D{
+					{Key: "value", Value: bson.D{
+						{Key: "_id", Value: objectID},
+						{Key: UserBlogMgoFieldUserId, Value: c.data.UserId},
+						{Key: UserBlogMgoFieldBlogId, Value: c.data.BlogId},
+						{Key: UserBlogMgoFieldContent, Value: c.data.Content},
+					}},
+					{Key: "ok", Value: 1},
+				}...)
+				t.AddMockResponses(findOneAndUpdateResp)
+				obj := c.data
+				_, err := obj.FindOneAndSave(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestInsertUnique tests the InsertUnique method
+func (s *UserBlogSuite) TestInsertUnique() {
+	cases := []struct {
+		name    string
+		data    UserBlog
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "insertUnique_success",
+			data: UserBlog{
+				// ID will be auto-generated
+				UserId:  3,
+				BlogId:  3,
+				Content: "unique_content",
+			},
+			query: bson.M{
+				"Content": "unique_content",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "ok", Value: 1},
+						{Key: "n", Value: 1},
+						{Key: "nModified", Value: 0},
+						{Key: "upserted", Value: bson.A{
+							bson.D{
+								{Key: "index", Value: 0},
+								{Key: "_id", Value: primitive.NewObjectID()},
+							},
+						}},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				saved, err := obj.InsertUnique(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.True(t, saved)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOne tests the FindOne method
+func (s *UserBlogSuite) TestFindOne() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "findOne_success",
+			query: bson.M{
+				"Content": "test_content",
+			},
+			sortFields: UserBlogMgoSortField_WRP{UserBlogMgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				findResp := mtest.CreateCursorResponse(1, "test.userblog", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserBlogMgoFieldUserId, Value: uint64(1)},
+					{Key: UserBlogMgoFieldBlogId, Value: uint64(1)},
+					{Key: UserBlogMgoFieldContent, Value: "test_content"},
+				})
+				t.AddMockResponses(findResp)
+				result, err := Get_UserBlogMgr().FindOne(s.ctx, c.query, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Equal(t, "test_content", result.Content)
+				}
+			})
+		})
+	}
+}
+
+// TestQuery tests the Query method
+func (s *UserBlogSuite) TestQuery() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "query_success",
+			query: bson.M{
+				"UserId": uint64(1),
+			},
+			limit:      10,
+			offset:     0,
+			sortFields: UserBlogMgoSortField_WRP{UserBlogMgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.userblog", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserBlogMgoFieldUserId, Value: uint64(1)},
+					{Key: UserBlogMgoFieldBlogId, Value: uint64(1)},
+					{Key: UserBlogMgoFieldContent, Value: "test_content_1"},
+				})
+				getMore := mtest.CreateCursorResponse(1, "test.userblog", mtest.NextBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserBlogMgoFieldUserId, Value: uint64(2)},
+					{Key: UserBlogMgoFieldBlogId, Value: uint64(2)},
+					{Key: UserBlogMgoFieldContent, Value: "test_content_2"},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.userblog", mtest.NextBatch)
+				t.AddMockResponses(first, getMore, killCursors)
+				cursor, err := Get_UserBlogMgr().Query(s.ctx, c.query, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, cursor)
+					// Close cursor to clean up
+					cursor.Close(s.ctx)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByUserId tests the FindByUserId method
+func (s *UserBlogSuite) TestFindByUserId() {
+	cases := []struct {
+		name       string
+		userid     uint64
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "findbyuserid_success",
+			userid:     uint64(1),
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.userblog", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserBlogMgoFieldUserId, Value: uint64(1)},
+					{Key: UserBlogMgoFieldBlogId, Value: uint64(1)},
+					{Key: UserBlogMgoFieldContent, Value: "test_content"},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.userblog", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserBlogMgr().FindByUserId(s.ctx, c.userid, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.userid, result[0].UserId)
+				}
+			})
+		})
+	}
+}
+
+func TestUserBlog(t *testing.T) {
+	suite.Run(t, &UserBlogSuite{})
+}

--- a/e2e/mongo/user/gen_User_mongo_orm.go
+++ b/e2e/mongo/user/gen_User_mongo_orm.go
@@ -15,6 +15,8 @@ import (
 // To import `time` package globally to satisfy `time.Time` index in yaml definition
 var _ time.Time
 
+const ColUser = "test_user"
+
 var UserIndexes = []mongo.IndexModel{
 	{
 		Keys: UserIndexKey_UsernameAge,
@@ -31,7 +33,7 @@ var UserIndexes = []mongo.IndexModel{
 }
 
 var UserIndexesFunc = func() {
-	orm.SetupIndexModel(Col("test_user"), UserIndexes)
+	orm.SetupIndexModel(Col(ColUser), UserIndexes)
 }
 var UserIndexKey_UsernameAge = bson.D{
 	{Key: "Username", Value: 1},

--- a/e2e/mongo/user/gen_User_mongo_orm_test.go
+++ b/e2e/mongo/user/gen_User_mongo_orm_test.go
@@ -1,0 +1,536 @@
+package user
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+type UserSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *UserSuite) SetupTest() {
+	s.ctx = context.TODO()
+}
+
+// TearDownTest runs after each test in the suite.
+func (s *UserSuite) TearDownTest() {
+}
+
+// TestSave tests the Save method with various scenarios
+func (s *UserSuite) TestSave() {
+	cases := []struct {
+		name    string
+		data    User
+		wantErr bool
+	}{
+		{
+			name: "save_success",
+			data: User{
+				// ID will be auto-generated
+				UserId:       1,
+				Username:     "test_username",
+				Age:          1,
+				RegisterDate: time.Now(),
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "acknowledged", Value: true},
+						{Key: "matchedCount", Value: 1},
+						{Key: "modifiedCount", Value: 1},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				_, err := obj.Save(s.ctx)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOneAndSave tests the FindOneAndSave method
+func (s *UserSuite) TestFindOneAndSave() {
+	cases := []struct {
+		name    string
+		data    User
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "findOneAndSave_success",
+			data: User{
+				// ID will be auto-generated
+				UserId:       2,
+				Username:     "test_username",
+				Age:          2,
+				RegisterDate: time.Now(),
+			},
+			query: bson.M{
+				"Username": "test_username",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				// FindOneAndUpdate returns the actual document
+				objectID := primitive.NewObjectID()
+				findOneAndUpdateResp := mtest.CreateSuccessResponse(bson.D{
+					{Key: "value", Value: bson.D{
+						{Key: "_id", Value: objectID},
+						{Key: UserMgoFieldUserId, Value: c.data.UserId},
+						{Key: UserMgoFieldUsername, Value: c.data.Username},
+						{Key: UserMgoFieldAge, Value: c.data.Age},
+						{Key: UserMgoFieldRegisterDate, Value: c.data.RegisterDate},
+					}},
+					{Key: "ok", Value: 1},
+				}...)
+				t.AddMockResponses(findOneAndUpdateResp)
+				obj := c.data
+				_, err := obj.FindOneAndSave(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestInsertUnique tests the InsertUnique method
+func (s *UserSuite) TestInsertUnique() {
+	cases := []struct {
+		name    string
+		data    User
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "insertUnique_success",
+			data: User{
+				// ID will be auto-generated
+				UserId:       3,
+				Username:     "unique_username",
+				Age:          3,
+				RegisterDate: time.Now(),
+			},
+			query: bson.M{
+				"Username": "unique_username",
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "ok", Value: 1},
+						{Key: "n", Value: 1},
+						{Key: "nModified", Value: 0},
+						{Key: "upserted", Value: bson.A{
+							bson.D{
+								{Key: "index", Value: 0},
+								{Key: "_id", Value: primitive.NewObjectID()},
+							},
+						}},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				saved, err := obj.InsertUnique(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.True(t, saved)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOne tests the FindOne method
+func (s *UserSuite) TestFindOne() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "findOne_success",
+			query: bson.M{
+				"Username": "test_username",
+			},
+			sortFields: UserMgoSortField_WRP{UserMgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				findResp := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Now()},
+				})
+				t.AddMockResponses(findResp)
+				result, err := Get_UserMgr().FindOne(s.ctx, c.query, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Equal(t, "test_username", result.Username)
+				}
+			})
+		})
+	}
+}
+
+// TestQuery tests the Query method
+func (s *UserSuite) TestQuery() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "query_success",
+			query: bson.M{
+				"UserId": uint64(1),
+			},
+			limit:      10,
+			offset:     0,
+			sortFields: UserMgoSortField_WRP{UserMgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username_1"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Now()},
+				})
+				getMore := mtest.CreateCursorResponse(1, "test.user", mtest.NextBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(2)},
+					{Key: UserMgoFieldUsername, Value: "test_username_2"},
+					{Key: UserMgoFieldAge, Value: int32(2)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Now()},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, getMore, killCursors)
+				cursor, err := Get_UserMgr().Query(s.ctx, c.query, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, cursor)
+					// Close cursor to clean up
+					cursor.Close(s.ctx)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByUsernameAge tests the FindByUsernameAge method
+func (s *UserSuite) TestFindByUsernameAge() {
+	cases := []struct {
+		name       string
+		username   string
+		age        int32
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "findbyusernameage_success",
+			username:   "test_username",
+			age:        int32(1),
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserMgr().FindByUsernameAge(s.ctx, c.username, c.age, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.username, result[0].Username)
+					assert.Equal(t, c.age, result[0].Age)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByUsername tests the FindByUsername method
+func (s *UserSuite) TestFindByUsername() {
+	cases := []struct {
+		name       string
+		username   string
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "findbyusername_success",
+			username:   "test_username",
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserMgr().FindByUsername(s.ctx, c.username, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.username, result[0].Username)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByAge tests the FindByAge method
+func (s *UserSuite) TestFindByAge() {
+	cases := []struct {
+		name       string
+		age        int32
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name:       "findbyage_success",
+			age:        int32(1),
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserMgr().FindByAge(s.ctx, c.age, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.age, result[0].Age)
+				}
+			})
+		})
+	}
+}
+
+// TestFindByRegisterDate tests the FindByRegisterDate method
+func (s *UserSuite) TestFindByRegisterDate() {
+	cases := []struct {
+		name         string
+		registerdate time.Time
+		limit        int
+		offset       int
+		sortFields   interface{}
+		wantErr      bool
+	}{
+		{
+			name:         "findbyregisterdate_success",
+			registerdate: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+			limit:        10,
+			offset:       0,
+			sortFields:   nil,
+			wantErr:      false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.user", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{Key: UserMgoFieldUserId, Value: uint64(1)},
+					{Key: UserMgoFieldUsername, Value: "test_username"},
+					{Key: UserMgoFieldAge, Value: int32(1)},
+					{Key: UserMgoFieldRegisterDate, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.user", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_UserMgr().FindByRegisterDate(s.ctx, c.registerdate, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					assert.Equal(t, c.registerdate.Unix(), result[0].RegisterDate.Unix())
+				}
+			})
+		})
+	}
+}
+
+func TestUser(t *testing.T) {
+	suite.Run(t, &UserSuite{})
+}

--- a/e2e/mongo/user/gen_User_mongo_orm_test.go
+++ b/e2e/mongo/user/gen_User_mongo_orm_test.go
@@ -12,6 +12,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
+var _ time.Time
+
 type UserSuite struct {
 	suite.Suite
 	ctx context.Context

--- a/e2e/mongo/user/user_test.go
+++ b/e2e/mongo/user/user_test.go
@@ -118,7 +118,9 @@ func TestOperateMultipleDB(t *testing.T) {
 	})
 }
 
-func TestSave(t *testing.T) {
+func TestE2ESave(t *testing.T) {
+	user.MgoSetup(getConfigFromEnv("ezorm"))
+
 	ctx := context.TODO()
 	u1 := user.Get_UserMgr().NewUser()
 	u1.Username = "username_1"

--- a/internal/parser/shared/obj.go
+++ b/internal/parser/shared/obj.go
@@ -31,6 +31,7 @@ func init() {
 		"strif":         strif,
 		"toids":         toIds,
 		"add":           add,
+		"lower":         strings.ToLower,
 	}
 
 	files := []string{
@@ -40,6 +41,7 @@ func init() {
 		"tpl/mysql_fk.gogo",
 		"tpl/mongo_config.gogo",
 		"tpl/mongo_orm.gogo",
+		"tpl/mongo_orm_test.gogo",
 		"tpl/mysql_script.sql",
 		"tpl/sql_method.gogo",
 	}
@@ -249,6 +251,7 @@ func (o *Obj) GetGenTypes() []string {
 			gens = append(gens, "struct")
 			if !o.IsEmbed {
 				gens = append(gens, "mongo_orm")
+				gens = append(gens, "mongo_orm_test")
 			}
 		case "enum":
 			gens = append(gens, "enum")

--- a/internal/parser/shared/tpl/mongo_config.gogo
+++ b/internal/parser/shared/tpl/mongo_config.gogo
@@ -12,12 +12,15 @@ import (
     "github.com/ezbuy/wrapper/database"
 
     "go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
 
 type SetupOption struct {
 	monitor database.Monitor
 	postHooks []func()
+	// mockStub is for mocking purpose
+	mockStub *mtest.T
 }
 
 type SetupOptionFn func(opts *SetupOption)
@@ -40,6 +43,12 @@ func WithPostHooks(fn ...func()) SetupOptionFn {
 	}
 }
 
+func WithMockStub(t *mtest.T) SetupOptionFn {
+	return func(opts *SetupOption) {
+		opts.mockStub = t
+	}
+}
+
 var mongoDriver *db.MongoDriver
 var mongoDriverOnce sync.Once
 
@@ -47,6 +56,16 @@ func MgoSetup(config *db.MongoConfig, opts ...SetupOptionFn) {
 	sopt := &SetupOption{}
 	for _, opt := range opts {
 		opt(sopt)
+	}
+	if sopt.mockStub != nil {
+		// reset the mongo driver if it was already initialized
+		mongoDriverOnce = sync.Once{}
+		mongoDriver = nil
+		mongoDriver = db.NewMockMongoDriver(sopt.mockStub)
+		for _, hook := range sopt.postHooks {
+			hook()
+		}
+		return
 	}
 	// setup the indexes
 	sopt.postHooks = append(sopt.postHooks,

--- a/internal/parser/shared/tpl/mongo_orm.gogo
+++ b/internal/parser/shared/tpl/mongo_orm.gogo
@@ -17,6 +17,8 @@ import (
 // To import `time` package globally to satisfy `time.Time` index in yaml definition
 var _ time.Time
 
+const Col{{.Name}} = "{{if eq .Table ""}}{{.Namespace}}.{{.Name}}{{else}}{{.Table}}{{end}}"
+
 {{if gt (len $obj.Indexes) 0}}
 var {{$obj.Name}}Indexes = []mongo.IndexModel{
     {{- range $index := $obj.Indexes}}
@@ -30,7 +32,7 @@ var {{$obj.Name}}Indexes = []mongo.IndexModel{
 }
 
 var {{$obj.Name}}IndexesFunc = func(){
-	orm.SetupIndexModel(Col({{if eq .Table ""}}"{{.Namespace}}.{{.Name}}"{{else}}"{{.Table}}"{{end}}),  {{$obj.Name}}Indexes)
+	orm.SetupIndexModel(Col(Col{{.Name}}),  {{$obj.Name}}Indexes)
 }
 {{- end }}
 

--- a/internal/parser/shared/tpl/mongo_orm_test.gogo
+++ b/internal/parser/shared/tpl/mongo_orm_test.gogo
@@ -1,0 +1,540 @@
+{{define "mongo_orm_test"}}package {{.GoPackage | lower}}
+{{$obj := .}}
+
+{{if ($obj.DbSwitch "mongo")}}
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
+)
+
+type {{.Name}}Suite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *{{.Name}}Suite) SetupTest() {
+	s.ctx = context.TODO()
+}
+
+// TearDownTest runs after each test in the suite.
+func (s *{{.Name}}Suite) TearDownTest() {
+}
+
+// TestSave tests the Save method with various scenarios
+func (s *{{.Name}}Suite) TestSave() {
+	cases := []struct {
+		name    string
+		data    {{.Name}}
+		wantErr bool
+	}{
+		{
+			name: "save_success",
+			data: {{.Name}}{
+				{{- range $field := .Fields}}
+				{{- if eq $field.Name "ID"}}
+				// ID will be auto-generated
+				{{- else if eq $field.Type "string"}}
+				{{$field.Name}}: "test_{{$field.Name | lower}}",
+				{{- else if eq $field.Type "int32"}}
+				{{$field.Name}}: 1,
+				{{- else if eq $field.Type "int64"}}
+				{{$field.Name}}: 1,
+				{{- else if eq $field.Type "uint64"}}
+				{{$field.Name}}: 1,
+				{{- else if eq $field.Type "time.Time"}}
+				{{$field.Name}}: time.Now(),
+				{{- else if eq $field.Type "bool"}}
+				{{$field.Name}}: true,
+				{{- else}}
+				{{$field.Name}}: {{$field.GetGoType}}{}, // TODO: Set appropriate test value
+				{{- end}}
+				{{- end}}
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "acknowledged", Value: true},
+						{Key: "matchedCount", Value: 1},
+						{Key: "modifiedCount", Value: 1},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				_, err := obj.Save(s.ctx)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOneAndSave tests the FindOneAndSave method
+func (s *{{.Name}}Suite) TestFindOneAndSave() {
+	cases := []struct {
+		name    string
+		data    {{.Name}}
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "findOneAndSave_success",
+			data: {{.Name}}{
+				{{- range $field := .Fields}}
+				{{- if eq $field.Name "ID"}}
+				// ID will be auto-generated
+				{{- else if eq $field.Type "string"}}
+				{{$field.Name}}: "test_{{$field.Name | lower}}",
+				{{- else if eq $field.Type "int32"}}
+				{{$field.Name}}: 2,
+				{{- else if eq $field.Type "int64"}}
+				{{$field.Name}}: 2,
+				{{- else if eq $field.Type "uint64"}}
+				{{$field.Name}}: 2,
+				{{- else if eq $field.Type "time.Time"}}
+				{{$field.Name}}: time.Now(),
+				{{- else if eq $field.Type "bool"}}
+				{{$field.Name}}: false,
+				{{- else}}
+				{{$field.Name}}: {{$field.GetGoType}}{}, // TODO: Set appropriate test value
+				{{- end}}
+				{{- end}}
+			},
+			query: bson.M{
+				{{- range $field := .Fields}}
+				{{- if and (ne $field.Name "ID") (eq $field.Type "string")}}
+				"{{$field.Name}}": "test_{{$field.Name | lower}}",
+				{{- break}}
+				{{- end}}
+				{{- end}}
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				// FindOneAndUpdate returns the actual document
+				objectID := primitive.NewObjectID()
+				findOneAndUpdateResp := mtest.CreateSuccessResponse(bson.D{
+					{Key: "value", Value: bson.D{
+						{Key: "_id", Value: objectID},
+						{{- range $field := .Fields}}
+						{{- if ne $field.Name "ID"}}
+						{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: c.data.{{$field.Name}}},
+						{{- end}}
+						{{- end}}
+					}},
+					{Key: "ok", Value: 1},
+				}...)
+				t.AddMockResponses(findOneAndUpdateResp)
+				obj := c.data
+				_, err := obj.FindOneAndSave(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			})
+		})
+	}
+}
+
+// TestInsertUnique tests the InsertUnique method
+func (s *{{.Name}}Suite) TestInsertUnique() {
+	cases := []struct {
+		name    string
+		data    {{.Name}}
+		query   bson.M
+		wantErr bool
+	}{
+		{
+			name: "insertUnique_success",
+			data: {{.Name}}{
+				{{- range $field := .Fields}}
+				{{- if eq $field.Name "ID"}}
+				// ID will be auto-generated
+				{{- else if eq $field.Type "string"}}
+				{{$field.Name}}: "unique_{{$field.Name | lower}}",
+				{{- else if eq $field.Type "int32"}}
+				{{$field.Name}}: 3,
+				{{- else if eq $field.Type "int64"}}
+				{{$field.Name}}: 3,
+				{{- else if eq $field.Type "uint64"}}
+				{{$field.Name}}: 3,
+				{{- else if eq $field.Type "time.Time"}}
+				{{$field.Name}}: time.Now(),
+				{{- else if eq $field.Type "bool"}}
+				{{$field.Name}}: true,
+				{{- else}}
+				{{$field.Name}}: {{$field.GetGoType}}{}, // TODO: Set appropriate test value
+				{{- end}}
+				{{- end}}
+			},
+			query: bson.M{
+				{{- range $field := .Fields}}
+				{{- if and (ne $field.Name "ID") (eq $field.Type "string")}}
+				"{{$field.Name}}": "unique_{{$field.Name | lower}}",
+				{{- break}}
+				{{- end}}
+				{{- end}}
+			},
+			wantErr: false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+
+				updateResp := mtest.CreateSuccessResponse(
+					bson.D{
+						{Key: "ok", Value: 1},
+						{Key: "n", Value: 1},
+						{Key: "nModified", Value: 0},
+						{Key: "upserted", Value: bson.A{
+							bson.D{
+								{Key: "index", Value: 0},
+								{Key: "_id", Value: primitive.NewObjectID()},
+							},
+						}},
+					}...,
+				)
+				t.AddMockResponses(updateResp)
+				obj := c.data
+				saved, err := obj.InsertUnique(s.ctx, c.query)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.True(t, saved)
+				}
+			})
+		})
+	}
+}
+
+// TestFindOne tests the FindOne method
+func (s *{{.Name}}Suite) TestFindOne() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "findOne_success",
+			query: bson.M{
+				{{- range $field := .Fields}}
+				{{- if and (ne $field.Name "ID") (eq $field.Type "string")}}
+				"{{$field.Name}}": "test_{{$field.Name | lower}}",
+				{{- break}}
+				{{- end}}
+				{{- end}}
+			},
+			sortFields: {{.Name}}MgoSortField_WRP{ {{.Name}}MgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				findResp := mtest.CreateCursorResponse(1, "test.{{.Name | lower}}", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{{- range $field := .Fields}}
+					{{- if ne $field.Name "ID"}}
+					{{- if eq $field.Type "string"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: "test_{{$field.Name | lower}}"},
+					{{- else if eq $field.Type "int32"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int32(1)},
+					{{- else if eq $field.Type "int64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int64(1)},
+					{{- else if eq $field.Type "uint64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: uint64(1)},
+					{{- else if eq $field.Type "time.Time"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: time.Now()},
+					{{- else if eq $field.Type "bool"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: true},
+					{{- else}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: nil}, // TODO: Set appropriate test value
+					{{- end}}
+					{{- end}}
+					{{- end}}
+				})
+				t.AddMockResponses(findResp)
+				result, err := Get_{{.Name}}Mgr().FindOne(s.ctx, c.query, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					{{- range $field := .Fields}}
+					{{- if and (ne $field.Name "ID") (eq $field.Type "string")}}
+					assert.Equal(t, "test_{{$field.Name | lower}}", result.{{$field.Name}})
+					{{- break}}
+					{{- end}}
+					{{- end}}
+				}
+			})
+		})
+	}
+}
+
+// TestQuery tests the Query method
+func (s *{{.Name}}Suite) TestQuery() {
+	cases := []struct {
+		name       string
+		query      bson.M
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "query_success",
+			query: bson.M{
+				{{- range $field := .Fields}}
+				{{- if and (ne $field.Name "ID") (eq $field.Type "int32")}}
+				"{{$field.Name}}": int32(1),
+				{{- break}}
+				{{- else if and (ne $field.Name "ID") (eq $field.Type "int64")}}
+				"{{$field.Name}}": int64(1),
+				{{- break}}
+				{{- else if and (ne $field.Name "ID") (eq $field.Type "uint64")}}
+				"{{$field.Name}}": uint64(1),
+				{{- break}}
+				{{- else if and (ne $field.Name "ID") (eq $field.Type "string")}}
+				"{{$field.Name}}": "test_{{$field.Name | lower}}",
+				{{- break}}
+				{{- end}}
+				{{- end}}
+			},
+			limit:      10,
+			offset:     0,
+			sortFields: {{.Name}}MgoSortField_WRP{ {{.Name}}MgoSortFieldIDAsc},
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.{{.Name | lower}}", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{{- range $field := .Fields}}
+					{{- if ne $field.Name "ID"}}
+					{{- if eq $field.Type "string"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: "test_{{$field.Name | lower}}_1"},
+					{{- else if eq $field.Type "int32"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int32(1)},
+					{{- else if eq $field.Type "int64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int64(1)},
+					{{- else if eq $field.Type "uint64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: uint64(1)},
+					{{- else if eq $field.Type "time.Time"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: time.Now()},
+					{{- else if eq $field.Type "bool"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: true},
+					{{- else}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: nil}, // TODO: Set appropriate test value
+					{{- end}}
+					{{- end}}
+					{{- end}}
+				})
+				getMore := mtest.CreateCursorResponse(1, "test.{{.Name | lower}}", mtest.NextBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{{- range $field := .Fields}}
+					{{- if ne $field.Name "ID"}}
+					{{- if eq $field.Type "string"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: "test_{{$field.Name | lower}}_2"},
+					{{- else if eq $field.Type "int32"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int32(2)},
+					{{- else if eq $field.Type "int64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int64(2)},
+					{{- else if eq $field.Type "uint64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: uint64(2)},
+					{{- else if eq $field.Type "time.Time"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: time.Now()},
+					{{- else if eq $field.Type "bool"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: false},
+					{{- else}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: nil}, // TODO: Set appropriate test value
+					{{- end}}
+					{{- end}}
+					{{- end}}
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.{{.Name | lower}}", mtest.NextBatch)
+				t.AddMockResponses(first, getMore, killCursors)
+				cursor, err := Get_{{.Name}}Mgr().Query(s.ctx, c.query, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, cursor)
+					// Close cursor to clean up
+					cursor.Close(s.ctx)
+				}
+			})
+		})
+	}
+}
+
+{{range $index := $obj.Indexes}}
+{{- if not $index.IsUnique}}
+// TestFindBy{{$index.Name}} tests the FindBy{{$index.Name}} method
+func (s *{{$obj.Name}}Suite) TestFindBy{{$index.Name}}() {
+	cases := []struct {
+		name       string
+		{{- range $field := $index.Fields}}
+		{{$field.Name | lower}}   {{$field.GetGoType}}
+		{{- end}}
+		limit      int
+		offset     int
+		sortFields interface{}
+		wantErr    bool
+	}{
+		{
+			name: "findby{{$index.Name | lower}}_success",
+			{{- range $field := $index.Fields}}
+			{{- if eq $field.Type "string"}}
+			{{$field.Name | lower}}: "test_{{$field.Name | lower}}",
+			{{- else if eq $field.Type "int32"}}
+			{{$field.Name | lower}}: int32(1),
+			{{- else if eq $field.Type "int64"}}
+			{{$field.Name | lower}}: int64(1),
+			{{- else if eq $field.Type "uint64"}}
+			{{$field.Name | lower}}: uint64(1),
+			{{- else if eq $field.Type "time.Time"}}
+			{{$field.Name | lower}}: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC),
+			{{- else if eq $field.Type "bool"}}
+			{{$field.Name | lower}}: true,
+			{{- else}}
+			{{$field.Name | lower}}: {{$field.GetGoType}}{}, // TODO: Set appropriate test value
+			{{- end}}
+			{{- end}}
+			limit:      10,
+			offset:     0,
+			sortFields: nil,
+			wantErr:    false,
+		},
+	}
+	mt := mtest.New(
+		s.T(),
+		mtest.NewOptions().ClientType(mtest.Mock),
+	)
+	defer mt.Close()
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			mt.Run(c.name, func(t *mtest.T) {
+				if t.Client == nil {
+					panic("t.Client is nil - mtest not properly initialized")
+				}
+				MgoSetup(nil, WithMockStub(t))
+				first := mtest.CreateCursorResponse(1, "test.{{$obj.Name | lower}}", mtest.FirstBatch, bson.D{
+					{Key: "_id", Value: primitive.NewObjectID()},
+					{{- range $field := $obj.Fields}}
+					{{- if ne $field.Name "ID"}}
+					{{- if eq $field.Type "string"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: "test_{{$field.Name | lower}}"},
+					{{- else if eq $field.Type "int32"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int32(1)},
+					{{- else if eq $field.Type "int64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: int64(1)},
+					{{- else if eq $field.Type "uint64"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: uint64(1)},
+					{{- else if eq $field.Type "time.Time"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)},
+					{{- else if eq $field.Type "bool"}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: true},
+					{{- else}}
+					{Key: {{$obj.Name}}MgoField{{$field.Name}}, Value: nil}, // TODO: Set appropriate test value
+					{{- end}}
+					{{- end}}
+					{{- end}}
+				})
+				killCursors := mtest.CreateCursorResponse(0, "test.{{$obj.Name | lower}}", mtest.NextBatch)
+				t.AddMockResponses(first, killCursors)
+				result, err := Get_{{$obj.Name}}Mgr().FindBy{{$index.Name}}(s.ctx, {{range $i, $field := $index.Fields}}{{if $i}}, {{end}}c.{{$field.Name | lower}}{{end}}, c.limit, c.offset, c.sortFields)
+				if c.wantErr {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+					assert.NotNil(t, result)
+					assert.Len(t, result, 1)
+					{{- range $field := $index.Fields}}
+					{{- if eq $field.Type "time.Time"}}
+					assert.Equal(t, c.{{$field.Name | lower}}.Unix(), result[0].{{$field.Name}}.Unix())
+					{{- else}}
+					assert.Equal(t, c.{{$field.Name | lower}}, result[0].{{$field.Name}})
+					{{- end}}
+					{{- end}}
+				}
+			})
+		})
+	}
+}
+{{- end}}
+{{- end}}
+
+func Test{{.Name}}(t *testing.T) {
+	suite.Run(t, &{{.Name}}Suite{})
+}
+{{end}}
+{{end}}

--- a/internal/parser/shared/tpl/mongo_orm_test.gogo
+++ b/internal/parser/shared/tpl/mongo_orm_test.gogo
@@ -14,6 +14,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 )
 
+var _ time.Time
+
 type {{.Name}}Suite struct {
 	suite.Suite
 	ctx context.Context

--- a/v2/pkg/db/mongodriver.go
+++ b/v2/pkg/db/mongodriver.go
@@ -8,6 +8,7 @@ import (
 
 	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -100,6 +101,13 @@ func NewMongoDriver(ctx context.Context, opts ...MongoDriverOption) (*MongoDrive
 	}
 
 	return &MongoDriver{cli: cli}, nil
+}
+
+func NewMockMongoDriver(t *mtest.T) *MongoDriver {
+	return &MongoDriver{
+		cli:    t.Client,
+		dbName: t.DB.Name(),
+	}
 }
 
 type MongoDriverOption func(*options.ClientOptions)


### PR DESCRIPTION
The main purpose of this PR is to support  [MongoDriver's mtest](https://github.com/mongodb/mongo-go-driver/tree/v1.17.3/mongo/integration/mtest): 

with mtest, we can: 

* Allow user to write the unit test code without the local mongo instance
* More stable CI with self-managed  `mogod` (which is in-memoy)